### PR TITLE
Collision rework

### DIFF
--- a/src/components/MatterMaker.tsx
+++ b/src/components/MatterMaker.tsx
@@ -189,6 +189,7 @@ export default function MatterMaker() {
       handler();
     });
 
+    // deletes bodies that move outside of the current screen range
     Events.on(engine, 'afterUpdate', () => {
       const height = render.options.height;
       const width = render.options.width;
@@ -217,17 +218,25 @@ export default function MatterMaker() {
     });
 
     Events.on(mouseConstraint, 'mousedown', (e) => {
-      const allBodies = Composite.allBodies(engine.world);
-      for (let body of allBodies) {
-        if (body.label === 'gravityCircle') {
-          Body.setStatic(body, false);
-        }
+      const clickedBody = e.source.body;
+      if (clickedBody?.label === 'gravityCircle') {
+        Body.setStatic(clickedBody, false);
+      } else {
+        return;
       }
+      // const allBodies = Composite.allBodies(engine.world);
+      // for (let body of allBodies) {
+      //   if (body.label === 'gravityCircle') {
+      //     Body.setStatic(body, false);
+      //   }
+      // }
+      //     }
+      //   }
     });
     Events.on(mouseConstraint, 'mouseup', (e) => {
       const allBodies = Composite.allBodies(engine.world);
       for (let body of allBodies) {
-        if (body.label === 'gravityCircle') {
+        if (body.label === 'gravityCircle' && !body.isStatic) {
           Body.setStatic(body, true);
         }
       }

--- a/src/components/MatterMaker.tsx
+++ b/src/components/MatterMaker.tsx
@@ -4,7 +4,7 @@ import Controls from './Controls';
 import { fixedSound, randomChord, drone1 } from './sounds';
 import { debounce } from 'debounce';
 import Matter, { Body, Engine, IEventCollision } from 'matter-js';
-import { backgroundColorGen } from '../utils/colorGen';
+import { generateBackgroundColor } from '../utils/colorGen';
 import {
   createCircle,
   createRandomTriangle,
@@ -85,7 +85,6 @@ export default function MatterMaker() {
   // }
 
   useEffect(() => {
-    console.log('innerwidth', window.innerWidth);
     // create a renderer
     const render = Render.create({
       element: canvasRef.current || document.body,
@@ -123,7 +122,7 @@ export default function MatterMaker() {
       const nextChordOption = collidedSquare.nextChord();
       collidedSquare.render.fillStyle = nextChordOption.color;
       collidedSquare.sound = nextChordOption.sound;
-      render.options.background = `#${backgroundColorGen()}`;
+      render.options.background = `#${generateBackgroundColor()}`;
     };
     const handleHexagonCollisionStart = (e: IEventCollision<Engine>) => {
       drone1.play();
@@ -153,6 +152,11 @@ export default function MatterMaker() {
     );
     const debouncedHandleHexagonCollisionStart = debounce(handleHexagonCollisionStart, 100, true);
 
+    /** library for collision handlers.
+     * MatterJS does not support per-body collision detection,
+     * recommnded solution was to iterate through all collision events
+     * and search for the one looking for, but creating handler "library"
+     * was much more efficient */
     const collisionStartHandlers = {
       circle: debouncedHandleCircleCollisionStart,
       triangle: debouncedHandleTriangleCollisionStart,

--- a/src/utils/bodies.ts
+++ b/src/utils/bodies.ts
@@ -74,7 +74,7 @@ export function createRandomTriangle(
 export function createGravityCircle(
   x = Math.random() * (window.innerWidth * 0.8),
   y = Math.random() * (window.innerHeight * 0.8),
-  radius = 90
+  radius = Math.random() * 90 + 50
 ) {
   return Matter.Bodies.circle(x, y, radius, {
     density: 1000000000000,

--- a/src/utils/colorGen.ts
+++ b/src/utils/colorGen.ts
@@ -1,7 +1,7 @@
 import { grabRandomUniqueIndex } from './orderLogic';
 const backgroundColors = ['BCE784', '5DD39E', '348AA7', '525174', '513B56'];
 
-export function backgroundColorGen() {
+export function generateBackgroundColor() {
   let randomIndex = grabRandomUniqueIndex(backgroundColors);
   const randomColor = backgroundColors[randomIndex];
   return randomColor;


### PR DESCRIPTION
This is a good one! 

Previously I simulated being able to move the gravity circle via mouse by disabling all 'gravityCircle's "static"-ness, while the mouse was down, but it looked terrible because all gravity circles visibly get pushed around by other bodies when the mouse was held down anywhere. 

Found out that you can actually access the specific body that you clicked on, and now it will NOT remove the "static" ness from other gravity circles when mouse is held down